### PR TITLE
many bugs with Spots fixed

### DIFF
--- a/frontend/src/components/LoginFormModal/index.js
+++ b/frontend/src/components/LoginFormModal/index.js
@@ -39,6 +39,7 @@ function LoginFormModal() {
       <form className="loginForm" onSubmit={handleSubmit}>
         <div className="loginDiv">
           <h2 className="loginTitle">Log In</h2>
+          <p className="loginError error">{errors.credential ? errors.credential: "                                                "}</p>
           <input
             className="loginCredentialInput"
             type="text"
@@ -57,7 +58,6 @@ function LoginFormModal() {
             onChange={(e) => setPassword(e.target.value)}
             required
           />
-          <p className="loginError error">{errors.credential ? errors.credential: "                                                "}</p>
         <button disabled={credential.length < 4 || password.length < 6} className="loginButton" type="submit">Log In</button>
         <button className="demoUserButton" type="button" onClick={(e) => demoUserActivated(e)}>Demo User</button>
         </div>

--- a/frontend/src/components/ManageSpots/ManageSpots.css
+++ b/frontend/src/components/ManageSpots/ManageSpots.css
@@ -1,3 +1,0 @@
-footer {
-    margin: unset;
-}

--- a/frontend/src/components/ManageSpots/index.js
+++ b/frontend/src/components/ManageSpots/index.js
@@ -1,26 +1,35 @@
 // frontend/src/components/ManageSpots/index.js
-import {  useSelector } from 'react-redux';
-// import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
-import "./ManageSpots.css"
-// import { thunkREADALLUserSpots } from '../../store/spots';
-
+import { thunkREADAllUserSpots } from '../../store/spots';
 import SpotTile from '../SpotTile';
+import { useEffect } from 'react';
 
 
 const ManageSpots = () => {
     const sessionUser = useSelector(state => state.session.user);
     const spots = useSelector(state => state.spots?.userSpots)
-    // const dispatch = useDispatch();
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        async function getUserSpots() {
+            await dispatch(thunkREADAllUserSpots());
+        }
+        if (!sessionUser) return null;
+        if (!spots) getUserSpots();
+    }, [spots, sessionUser, dispatch]);
+
     if (!sessionUser) return null;
-    // if (!spots) {
-    //     dispatch(thunkREADALLUserSpots());
-    //     return null;
-    // }
+    if (!spots) {
+        (async() => await dispatch(thunkREADAllUserSpots()))();
+        return null;
+    }
+
 
     return (
         <div className="manageSpotsDiv">
-            {Object.values(spots).map(s => (
+            {(!Object.keys(spots).length && <p>No spots! Boo hoo</p>) ||
+            Object.values(spots).map(s => (
                 <SpotTile key={s.id} spot={s} isManaged={true} />
             ))}
         </div>

--- a/frontend/src/components/SpotForm/index.js
+++ b/frontend/src/components/SpotForm/index.js
@@ -63,7 +63,6 @@ function SpotForm ({spot, formType}) {
       if (supportUrl1 && !validImageUrl(supportUrl4)) validations.supportUrl4 = extensionError
       }
       setErrors(validations);
-      console.log("🚀 ~ file: index.js:61 ~ handleSubmit ~ validations:", validations)
       if (Object.keys(validations).length === 0) {
           const thunkFunc = isEdit ? thunkUPDATESpot : thunkCREATESpot;
           if (!isEdit) {
@@ -73,13 +72,10 @@ function SpotForm ({spot, formType}) {
           if (supportUrl3) urls.push(supportUrl3)
           if (supportUrl4) urls.push(supportUrl4)
           spot = await dispatch(thunkFunc(spot, {urls}))
-          } else spot = await dispatch(thunkFunc(spot))
+          } else await dispatch(thunkFunc(spot));
 
-
-          console.log("🚀 ~ file: index.js:72 ~ handleSubmit ~ spot:", spot)
           attemptedSubmission.current = false;
-          if (spot.id) history.push(`/spots/${spot.id}`);
-          else console.log("still haven't figured the right approach to getting the generated spot id from create spot back to the component")
+          history.push(`/spots/${spot.id}`);
         }
     };
 
@@ -210,17 +206,15 @@ function SpotForm ({spot, formType}) {
     <h2>Liven up your spot with photos</h2>
     <p>Submit a link to at least one photo to publish your spot.</p>
     <input type="text" value={previewUrl} autoComplete="photo" placeholder="Preview Image URL" onChange={e => setPreviewUrl(e.target.value)} />
-    <p className="error"> {attemptedSubmission && errors.previewUrl && errors.previewUrl}</p>
-    <fieldset disabled={previewUrl === ''}>
-    <input type="text" value={supportUrl1} onChange={e=>setSupportUrl1(e.target.value)} autoComplete="photo" placeholder="Image URL" />
-    <p className="error">{attemptedSubmission && errors.setSupportUrl1 && errors.supportUrl1}</p>
-    <input type="text" value={supportUrl2} onChange={e=>setSupportUrl2(e.target.value)} autoComplete="photo" placeholder="Image URL" />
-    <p className="error">{attemptedSubmission && errors.setSupportUrl2 && errors.supportUrl2}</p>
-    <input type="text" value={supportUrl3} onChange={e=>setSupportUrl3(e.target.value)} autoComplete="photo" placeholder="Image URL" />
-    <p className="error">{attemptedSubmission && errors.setSupportUrl3 && errors.supportUrl3}</p>
-    <input type="text" value={supportUrl4} onChange={e=>setSupportUrl4(e.target.value)} autoComplete="photo" placeholder="Image URL" />
-    <p className="error">{attemptedSubmission && errors.setSupportUrl4 && errors.supportUrl4}</p>
-    </fieldset>
+    <p> </p><p className="error">{attemptedSubmission && errors.previewUrl && errors.previewUrl}</p>
+    <input type="text" value={supportUrl1} onChange={e=>setSupportUrl1(e.target.value)} autoComplete="photo" placeholder="Image URL" disabled={previewUrl === ''} />
+    <p className="error">{attemptedSubmission && errors.supportUrl1 && errors.supportUrl1}</p>
+    <input type="text" value={supportUrl2} onChange={e=>setSupportUrl2(e.target.value)} autoComplete="photo" placeholder="Image URL" disabled={previewUrl === ''} />
+    <p className="error">{attemptedSubmission && errors.supportUrl2 && errors.supportUrl2}</p>
+    <input type="text" value={supportUrl3} onChange={e=>setSupportUrl3(e.target.value)} autoComplete="photo" placeholder="Image URL" disabled={previewUrl === ''} />
+    <p className="error">{attemptedSubmission && errors.supportUrl3 && errors.supportUrl3}</p>
+    <input type="text" value={supportUrl4} onChange={e=>setSupportUrl4(e.target.value)} autoComplete="photo" placeholder="Image URL" disabled={previewUrl === ''}/>
+    <p className="error">{attemptedSubmission && errors.supportUrl4 && errors.supportUrl4}</p>
     <hr></hr>
     </section>}
     <button className="spotFormSubmitButton" type="submit">{isEdit ? formType : "Create Spot"}</button>

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -240,7 +240,7 @@ export const thunkUPDATESpot = (spot /*, urls */) => async dispatch => {
   */
   console.log("🚀 ~ file: spots.js:210 ~ thunkUPDATESpot ~ spot:", spot)
   const data = await response.json();
-  dispatch(updateSpot(data.spot));
+  dispatch(updateSpot(data));
   return response;
 };
 
@@ -251,7 +251,7 @@ function copyNormWithout(oldNorm, key) {
    */
   if (!oldNorm || !oldNorm[key]) return oldNorm;
   const result = {};
-  oldNorm.forEach(k => {if (k !== key) result[k] = oldNorm[k]});
+  Object.keys(oldNorm).forEach(k => {if (k !== key) result[k] = oldNorm[k]});
   return result;
 }
 
@@ -285,15 +285,19 @@ const spotsReducer = (state = initialState, action) => {
       newState.allSpots = {...state.allSpots, [id]: spot};
       if (state.session?.user?.id === spot.ownerId)
         newState.userSpots = {...state.userSpots, [id]: spot};
+      if (state.singleSpot?.id === id)
+        newState.singleSpot = {...state.singleSpot, ...spot}
       return newState;
     }
     case READ_SPOT: {
-      const spot = action.payload
-      const id = spot.id;
+      const id = action.payload.id;
+      const previewImage = action.payload.SpotImages.find(e => e.preview).url;
+      const spot = {...action.payload, previewImage};
       newState = {...state};
-      newState.allSpots = {...state.allSpots, [id]: (newState.singleSpot = spot)};
+      newState.singleSpot = spot;
+      newState.allSpots = {...state.allSpots,  [id]: spot};
       if (state.session?.user?.id === spot.ownerId)
-        newState.userSpots = {...state.userSpots, [id]: spot};
+        newState.userSpots = {...state.userSpots,  [id]: spot};
       return newState;
     }
 

--- a/images/imageLinks.txt
+++ b/images/imageLinks.txt
@@ -20,23 +20,36 @@ started changes to seeders based on getting more requirements method
   all reviews have an image
   every spot has 5-10 reviews by appropriate non-owners with
      random text and rating
+  update previewUrl in singleSpot in reducer (should change DB)
+  moved login db errors under heading
+  getting newly created spot id after create spot
+    to correctly go to the spot details page
+  fixed update bug
+  CreateSpot lists support images vertically
+  EditSpot ignores all images
+  SpotForm  ANd PUT
+    error messages in them correctly for create.
 
 
 ISSUES
-after click on spot details and using browser back button, that spot
-  no longer displays its preview image on landing page
-Error on update thunk: undefined, not spot data, passed into action creator wrong, hits in reducer
-login db errors under heading
-SpotForm needs to list urls vertically,
-  and ignore them for Update. ANd PUT
-  error messages in them correctly.
-back to some issue with creating a spot
-getting newly created spot id after create spot
-  to correctly go to the spot details page
-Update correctly for Delete Spot for user
-Spots for user should be listed in updateDate order
-(new added to beginning)
 Browser refresh doesn't update Manage Spots
+Reviews add to SpotDetails
+Callout box add to SpotDetails
+Adding Callout with price night, small review avg, Reserve button
+StarRatings add to SpotDetails' callout box
+CreateReview
+DeleteReview
+Review List of Review Tiles (in update order; new added to beginning)
+    Review Tile has
+    Star Rating string
+    Post Your Review optional button
+    If No Reviews, then optional Be the first to post a review! string
+    FirstName of reviewer
+    Optional Delete button (if your review)
+Post Your Review opens modal dialog for inputting Review
+Need open star icon for review rating with Paw Print functionality
+Delete button opens modal dialog for deleting Review
+On delete, review counts and averages need to be updated
 
 Subheading size too large
 Subheading weight too heavy
@@ -48,33 +61,13 @@ Submit button needs to be centered and colored
 Remove DEFAULT button (LAST THING)
 Comma misplaced on Create Spot (city, state)
 Confirm spot image creation working NO
-Delete Spot does not cause update on ManageSpots previewImage
-Successful new Spot creation takes to SpotDetails
 Have reasonable image sizing (tiles should be 3x6)
-Reviews add to SpotDetails
-Callout box add to SpotDetails
-StarRatings add to SpotDetails
-CreateReview
-DeleteReview
 CSS Delete Spot modal
 CSS not-logged-in menu
 CSS sign up dialog form
 
-
 Adding Fake descriptive text for host
-Adding Callout with price night, small review avg, Reserve button
 Adding divider on Spot details
-List of Review Tiles (in update order; new added to beginning)
-    Review Tile has
-    Star Rating string
-    Post Your Review optional button
-    If No Reviews, then optional Be the first to post a review! string
-    FirstName of reviewer
-    Optional Delete button (if your review)
-Post Your Review opens modal dialog for inputting Review
-Need open star icon for review rating with Paw Print functionality
-Delete button opens modal dialog for deleting Review
-On delete, review counts and averages need to be updated
 
 Understanding entire flow of error-handling and implementing correctly
 from front request with thunk to thunk fetch (I understand backend, and
@@ -93,8 +86,6 @@ header spacing: added bottom to allow ManageSpots to work: modal apparently
     NOT on top of other elements
 
 More:
-Create Review
-Delete Review
 
 FINALLY CSS
 Form placeholder text lighter
@@ -102,7 +93,6 @@ price "night", star rating "review" both darker
 
 
 
-image pics, server vs local copies, changing specified
 Making default to show no image present
 Generate large amount of data
 Have SpotForm show first 4 validation error messages to side of label


### PR DESCRIPTION
removed null bug introduced in Friday changes to session reducer
started changes to seeders based on getting more requirements method
  30 char in spot description
  preview always state
  some supporting images
  all reviews have an image
  every spot has 5-10 reviews by appropriate non-owners with
     random text and rating
  update previewUrl in singleSpot in reducer (should change DB)
  moved login db errors under heading
  getting newly created spot id after create spot
    to correctly go to the spot details page
  fixed update bug
  CreateSpot lists support images vertically
  EditSpot ignores all images
  SpotForm  ANd PUT
    error messages in them correctly for create.