### PR TITLE
Dev

### DIFF
--- a/backend/changesToPostmanTest.txt
+++ b/backend/changesToPostmanTest.txt
@@ -4,21 +4,17 @@ Errors in API I corrected
     2 500s should be 400s
     1 500 should be 403
     Several (4?) 200s should be 201s (that create new table rows)
-    It IS OK for a startDate and different booking endDate to be the same.
-    People leave in the morning and come in the evening. (Similarly for
-    endDates)
-    Allow owner to make booking of own spot (implementation of unavailable)
-change all review things to look for commentary instead of review
-
-Errors in script:
-  line 12 of POST Signup needs ()s after keyword function
+    It IS OK for a startDate and different booking endDate to be the same. (endDates end before noon; startDates start in the evening)
+    Allow owner to make booking of own spot (easy implementation of making Spot unavailable for booking)
+    change all review test scripts to look for commentary instead of review
+    changed create image API to handle incoming array and return array
 
 
 
 Investigate if you can run something before test script run
 
 if cascade delete is set appropriately, only this one delete
-command needs to run to clean up after a rest:
+command needs to run to clean up after a script run:
 DELETE FROM Users WHERE lastName='AATester';
 Ensure no cookies, or perhaps run option don't use cookies
 

--- a/backend/db/seeders/20230902213657-demo-reviews.js
+++ b/backend/db/seeders/20230902213657-demo-reviews.js
@@ -22,7 +22,7 @@ module.exports = {
     // generate 1-10 reviews by non-owners;
     const generatedReviews = [];
     for (const spot of spots) {
-      const numReviews = getRandomInt(1,10);
+      const numReviews = getRandomInt(1,3); /* TODO change back to 10 */
       const filteredIds = userIds.filter(id => id !== spot.ownerId);
       const startIndex = getRandomInt(0, filteredIds.length-(numReviews+1));
       const spotId = spot.id;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,10 +10,14 @@ import SpotCreate from "./components/SpotCreate";
 import SpotDetails from "./components/SpotDetails";
 import SpotEdit from "./components/SpotEdit";
 import SpotList from "./components/SpotList";
+import { restoreCSRF } from "./store/csrf";
 
 function App() {
   const dispatch = useDispatch();
   const [isLoaded, setIsLoaded] = useState(false);
+
+  restoreCSRF()
+
   useEffect(() => {
     dispatch(sessionActions.restoreUser()).then(() => setIsLoaded(true));
   }, [dispatch]);

--- a/frontend/src/components/ManageSpots/index.js
+++ b/frontend/src/components/ManageSpots/index.js
@@ -8,13 +8,14 @@ import SpotTile from '../SpotTile';
 
 
 const ManageSpots = () => {
+    console.log("manage spots render attempt")
     const user = useSelector(state => state.session.user);
     const spotIds = useSelector(state => state.session.spots)
     const dispatch = useDispatch();
     const history = useHistory();
 
     const ref = useRef({});
-    if (!spotIds) { // have top level, check for inner need
+    if (!spotIds || !Array.isArray(spotIds)) {
         if (!ref.current[user.id]) ref.current[user.id] = dispatch(thunkReadAllUserSpots())
         return null;
     } else if (ref.current[user.id]) delete ref.current[user.id]
@@ -35,7 +36,7 @@ const ManageSpots = () => {
         <div className="manageSpotsDiv">
           <div className="manageSpotTilesDiv">
           {spotIds.map(s => (
-                <SpotTile key={s} spotId={s}isManaged={true} />
+                <SpotTile key={s} spotId={s} isManaged={true} />
             ))}
           </div>
         </div>

--- a/frontend/src/components/ReviewList/index.js
+++ b/frontend/src/components/ReviewList/index.js
@@ -19,8 +19,10 @@ function ReviewList({ spot }) {
     }, [reviewIds,dispatch, spot.id])
 
     // ok to have 0 reviews; may be new, etc.
-    if (spot.numReviews === 0) return null
-    if (!reviewIds) return null
+    if (!Array.isArray(reviewIds)) {
+      console.log("reviewIds should be an empty array if no reviews if not empty, then ordered by descending updatedAt timestamp or undefined if never determined from db; spot.numReviews, typeof reviewIds: ", spot.numReviews, typeof reviewIds);
+      return null
+    }
     if (reviewIds.includes(null) || reviewIds.includes(undefined)) {
       console.log("baaad review id; ", reviewIds)
       return null

--- a/frontend/src/components/SpotDetails/index.js
+++ b/frontend/src/components/SpotDetails/index.js
@@ -9,8 +9,10 @@ import SpotDetailReviewArea from "../SpotDetailReviewArea";
 
 function SpotDetails() {
     const { id } = useParams();
+    console.log("🚀 ~invoking SpotDetails ~ id:", id)
+    const ref = useRef({});
     const spot = useSelector(state => state.spots.id[id])
-    const imageIds = useSelector(state => state.spots.id[id].images)
+    const imageIds = useSelector(state => state.spots.id[id]?.images)
     const dispatch = useDispatch();
     const spotImages = useSelector(state => state.spotImages.id);
     let otherImages = []
@@ -18,13 +20,11 @@ function SpotDetails() {
     // const [rerender, setRerender] = useState({})
 
 
-  const ref = useRef({});
   if (!imageIds) {
-    // setTimeout(()=>setRerender({old: rerender}), 1000)
-    console.log("thunkReadSpot(id) going to invoke", id)
-    if (!ref.current[id]) {
-        ref.current[id] = true;
-    dispatch(thunkReadSpot(id))
+      if (!ref.current[id]) {
+          ref.current[id] = true;
+        console.log(`thunkReadSpot(${id}) going to invoked`)
+        dispatch(thunkReadSpot(id))
     }
     return null;
   } else if (ref.current[id]) delete ref.current[id]
@@ -38,6 +38,8 @@ function SpotDetails() {
   function handleReserveClick(){
       alert("Feature Coming Soon...")
   }
+
+  console.log("rendering SpotDetails")
 
   return (
     <div className="spotDetailsDiv">

--- a/frontend/src/components/SpotTile/index.js
+++ b/frontend/src/components/SpotTile/index.js
@@ -12,6 +12,7 @@ const placeholderSrc = "https://placehold.co/100?text=Photo+needed&font=montserr
 
 function SpotTile ({spotId, spot, isManaged}) {
   console.log("🚀 rendering SpotTile ~ spotId, spot:", spotId, spot)
+  const ref = useRef({});
   const stateSpot = useSelector(state => state.spots.id[spotId])
   const history = useHistory();
   const dispatch = useDispatch();
@@ -31,7 +32,6 @@ function SpotTile ({spotId, spot, isManaged}) {
   }
 
 
-  const ref = useRef({});
   if (!spot || Object.values(spot).length < 2) {
     if (!ref.current[spotId])
       ref.current[spotId] = dispatch(thunkReadSpot(spotId))

--- a/frontend/src/components/SpotTile/index.js
+++ b/frontend/src/components/SpotTile/index.js
@@ -15,7 +15,8 @@ function SpotTile ({spotId, spot, isManaged}) {
   const stateSpot = useSelector(state => state.spots.id[spotId])
   const history = useHistory();
   const dispatch = useDispatch();
-  const ref = useRef();
+
+  if (isManaged) spot = stateSpot;
 
   function handleUpdateClick() {
     if (stateSpot !== true)
@@ -29,16 +30,13 @@ function SpotTile ({spotId, spot, isManaged}) {
     history.push(`/spots/${spotId}`)
   }
 
-  if (!spotId) throw new Error("bad id for Spot Tile")
-  if (!spot) spot = stateSpot;
 
+  const ref = useRef({});
   if (!spot || Object.values(spot).length < 2) {
-    if (!ref.current[spotId]) ref.current[spotId] = dispatch(thunkReadSpot(spotId))
+    if (!ref.current[spotId])
+      ref.current[spotId] = dispatch(thunkReadSpot(spotId))
     return null;
-} else if (ref.current[spotId]) delete ref.current[spotId]
-
-if (!spot) return null;
-
+  } else if (ref.current[spotId]) delete ref.current[spotId]
 
   return (
     <div className="tileDiv">

--- a/frontend/src/components/SpotTile/index.js
+++ b/frontend/src/components/SpotTile/index.js
@@ -1,4 +1,5 @@
 // frontend/src/components/SpotTile/index.js
+import { useRef } from 'react';
 import { useHistory } from 'react-router-dom/';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -14,7 +15,7 @@ function SpotTile ({spotId, spot, isManaged}) {
   const stateSpot = useSelector(state => state.spots.id[spotId])
   const history = useHistory();
   const dispatch = useDispatch();
-
+  const ref = useRef();
 
   function handleUpdateClick() {
     if (stateSpot !== true)
@@ -28,10 +29,15 @@ function SpotTile ({spotId, spot, isManaged}) {
     history.push(`/spots/${spotId}`)
   }
 
-  if (!spot) {
-    (async()=>await(dispatch(thunkReadSpot(spotId))))()
+  if (!spotId) throw new Error("bad id for Spot Tile")
+  if (!spot) spot = stateSpot;
+
+  if (!spot || Object.values(spot).length < 2) {
+    if (!ref.current[spotId]) ref.current[spotId] = dispatch(thunkReadSpot(spotId))
     return null;
-  }
+} else if (ref.current[spotId]) delete ref.current[spotId]
+
+if (!spot) return null;
 
 
   return (

--- a/frontend/src/store/commonActionCreators.js
+++ b/frontend/src/store/commonActionCreators.js
@@ -2,8 +2,15 @@
 Most actionCreators will be found in the store .js file containing the reducer for that slice; but some are needed to be handled by multiple slices, and to avoid a circular reference we have to have a common external file that all dependendent slices import; similarly we have to have the constant used as the type available for all interested reducers
 */
 
-export const DELETE_SPOT = "spots/DELETE_SPOT";
+export const CREATED_REVIEW = "reviews/CREATED_REVIEW";
+export const CREATED_SPOT = "spots/CREATED_SPOT";
+
+export const DELETED_REVIEW = "reviews/DELETED_REVIEW";
+
+export const DELETED_SPOT = "spots/DELETED_SPOT";
 export const READ_SPOT_REVIEWS = "reviews/READ_SPOT_REVIEWS"; /* spot */
 export const READ_USER_REVIEWS = "reviews/READ_USER_REVIEWS"; /* session */
 export const READ_SPOT = "spots/READ_SPOT"; /* session, spotImage */
 export const READ_USER_SPOTS = "spots/READ_USER_SPOTS";
+export const UPDATED_REVIEW = "reviews/UPDATED_REVIEW";
+export const UPDATED_SPOT_REVIEW_RATINGS = "reviews/UPDATED_SPOT_REVIEW_RATINGS";

--- a/frontend/src/store/commonActionCreators.js
+++ b/frontend/src/store/commonActionCreators.js
@@ -2,6 +2,7 @@
 Most actionCreators will be found in the store .js file containing the reducer for that slice; but some are needed to be handled by multiple slices, and to avoid a circular reference we have to have a common external file that all dependendent slices import; similarly we have to have the constant used as the type available for all interested reducers
 */
 
+export const DELETE_SPOT = "spots/DELETE_SPOT";
 export const READ_SPOT_REVIEWS = "reviews/READ_SPOT_REVIEWS"; /* spot */
 export const READ_USER_REVIEWS = "reviews/READ_USER_REVIEWS"; /* session */
 export const READ_SPOT = "spots/READ_SPOT"; /* session, spotImage */

--- a/frontend/src/store/reviewImages.js
+++ b/frontend/src/store/reviewImages.js
@@ -155,7 +155,7 @@ const reviewImagesReducer = (state = initialState, action) => {
       return newState
     }
     case READ_SPOT_REVIEWS:
-      case READ_USER_REVIEWS:{
+      case READ_USER_REVIEWS: {
       const newState = {...state}
       const reviews = action.payload
       const normalized = {}

--- a/frontend/src/store/session.js
+++ b/frontend/src/store/session.js
@@ -167,25 +167,32 @@ const sessionReducer = (state = initialState, action) => {
     case DELETED_SPOT: {
       newState.user = {...state.user}
       const index = state.spots.indexOf(action.payload.id)
-      if (index !== -1)
-        newState.spots = newState.user.spots = [...state.spots].splice(index,1)
+      if (index === -1) return state
+      newState.spots = newState.user.spots = [...state.spots]
+      newState.spots.splice(index, 1)
       return newState
     }
     case DELETED_REVIEW: {
+      console.log("delReview action.payload", action.payload)
       newState.user = {...state.user}
       const index = state.reviews.indexOf(action.payload.reviewId)
-      if (index !== -1)
-        newState.reviews = newState.user.reviews = [...state.reviews].splice(index,1)
+      console.log("delReview index, reviews", index, state.reviews)
+      if (index === -1) return state;
+      newState.reviews = newState.user.reviews = [...state.reviews]
+      newState.reviews.splice(index, 1)
+      console.log("new reviews", newState.reviews)
       return newState
     }
     case CREATED_REVIEW: {
       newState.user = {...state.user}
-      newState.reviews = newState.user.reviews = [...state.reviews, action.payload.review.id]
+      const old = state.reviews ? state.reviews : []
+      newState.reviews = newState.user.reviews = [...old, action.payload.review.id]
       return newState
     }
     case CREATED_SPOT: {
       newState.user = {...state.user}
-      newState.spots = newState.user.spots = [...state.spots, action.payload.id]
+      const old = state.spots ? state.spots : []
+      newState.spots = newState.user.spots = [...old, action.payload.id]
       return newState
     }
     default:

--- a/frontend/src/store/session.js
+++ b/frontend/src/store/session.js
@@ -45,7 +45,7 @@ and without logged-in user
  */
 
 import { csrfFetch, fetchData } from "./csrf";
-import { READ_SPOT, READ_USER_REVIEWS, READ_USER_SPOTS } from "./commonActionCreators";
+import { DELETE_SPOT, READ_SPOT, READ_USER_REVIEWS, READ_USER_SPOTS } from "./commonActionCreators";
 
 const SET_USER = "session/setUser";
 const REMOVE_USER = "session/removeUser";
@@ -147,7 +147,7 @@ const sessionReducer = (state = initialState, action) => {
       const reviews = action.payload.map(r => r.id)
       newState.user = {...state.user}
       newState.id = {...state.id}
-      newState.reviews = newState.user.reviews = newState.id[state.user.id] = reviews
+      newState.reviews = newState.user.reviews = reviews
       return newState
     }
     case READ_USER_SPOTS: {
@@ -155,6 +155,13 @@ const sessionReducer = (state = initialState, action) => {
       newState.user = {...state.user}
       newState.spots = newState.user.spots = spots;
       return newState;
+    }
+    case DELETE_SPOT: {
+      const newState = {...state}
+      const index = state.spots.indexOf(action.payload.id)
+      if (index !== -1)
+        newState.spots = newState.user.spots = [...state.spots].splice(index,1)
+      return newState
     }
     default:
       return state;

--- a/frontend/src/store/spots.js
+++ b/frontend/src/store/spots.js
@@ -112,12 +112,11 @@ in state.spots.id
 }
 */
 
-import { READ_SPOT, READ_SPOT_REVIEWS, READ_USER_SPOTS } from "./commonActionCreators";
+import { DELETE_SPOT, READ_SPOT, READ_SPOT_REVIEWS, READ_USER_SPOTS } from "./commonActionCreators";
 
 import { csrfFetch, fetchData, jsonHeaderContent } from "./csrf";
 
 const READ_SPOTS = "spots/READ_SPOTS";
-const DELETE_SPOT = "spots/DELETE_SPOT";
 const CREATE_SPOT = "spots/CREATE_SPOT";
 const UPDATE_SPOT = "spots/UPDATE_SPOT";
 
@@ -171,7 +170,7 @@ export const thunkReadAllSpots = () => async dispatch => {
 }
 
 
-export const thunkReadAllUserSpots = (args) => async dispatch => {
+export const thunkReadAllUserSpots = () => async dispatch => {
   const url = '/api/spots/current'
   const answer = await fetchData(url)
   if (!answer.errors) dispatch(readAllUserSpots(answer.Spots))
@@ -313,7 +312,6 @@ const spotsReducer = (state = initialState, action) => {
       newState = {...state};
       newState.id = {...state.id};
       delete newState.id[action.payload]
-      newState.userQuery = {...state.userQuery};
       return newState;
 
     case READ_SPOT_REVIEWS: {

--- a/issues.txt
+++ b/issues.txt
@@ -52,3 +52,15 @@ Generate better, larger amount of data
 BUGS:
 Login on error (invalid password/credential) changes size,
 and a sliver of a modalDiv appears underneath main modal
+
+LONGTERM
+Figure out DB table constraints syntax for Sequelize for Sqlite3 & PostGreSQL (probably have to be literal SQL), and implementing
+appropriate table constraints which match application constraints where possible and put into migration files (better protection against bad seeding; although may make historical seeding hard; so may have to skip date checking)
+Put console logs at beginning of all component functions and just before
+return statements, and check that ACTUAL re-rendering is minimal.
+Use db transactions to rollback multi-table changes when errors occur after 1st table succeeds
+Switch to RTK and RTK Query
+Switch to Vite instead of CRA
+Change all READ items to GOT (past of GET)
+Make names more explicit (no "plain" ids)
+Figure out Render transfer approach

--- a/issues.txt
+++ b/issues.txt
@@ -2,11 +2,7 @@
 
 
 ISSUES
-Passing certain db errors like signup uniqueness for email/username back up.
 Figure out default image sizes and layout
-Adding Callout with price night, small review avg, Reserve button
-StarRatings add to SpotDetails' callout box
-Ensure spot delete updates landing pages/manage spot pages
 Use placeholders when users have not contributed enough images
 Have SpotForm show first 4 validation error messages to side of label
 Comma misplaced on Create Spot (city, state)

--- a/lastBranchNotes.txt
+++ b/lastBranchNotes.txt
@@ -2,15 +2,35 @@
 Last branch notes
 
 SATURDAY/SUNDAY
-Manage spots doesn't load
+Manage spots now loads
 can update freshly created spot
 delete spot changes no longer impact userId info
 Added Callout with price night, small review avg, Reserve button
 StarRatings added to SpotDetails' callout box
 Ensured spot delete updates landing pages/manage spot pages
+Create and then edit/update new spot works
+
+
+check every App start page for doing browser refresh and handling no current state information
+deleting review updates review slice correctly, but not session slice (sill in user.reviews and reviews)
+have created/updated/deleted reviews calculate and return numReviews and avgRating as well as spotId
+remove redundant user session settings (just depend on
+user object setting: reviews, spots, bookings)
+test and check all interdependency reducers are correct
+
+
 
 create review causes error for empty list
 Login modal doesn't autoclose after successful login
 
+review slice correctly updated with delete/create; however:
+spot not updated with create (but was with delete)
+session.reviews still has deleted review key; does NOT have created review key
+lack of create for both possibly because of error
+read spot reviews didn't corrrectly update spotLatest
+
+deleting spot should cascade in store and delete all associated
+reviews, bookings, spotImages,
+deleting review should cascade in store and delete all review images
 
 Check out create and edit spots; after getting Manage Spots

--- a/lastBranchNotes.txt
+++ b/lastBranchNotes.txt
@@ -9,15 +9,14 @@ Added Callout with price night, small review avg, Reserve button
 StarRatings added to SpotDetails' callout box
 Ensured spot delete updates landing pages/manage spot pages
 Create and then edit/update new spot works
+deleting review updates reviews/session/spots slices correctly
+created/updated/deleted reviews calculate and return numReviews and avgRating as well as spotId
 
-
-check every App start page for doing browser refresh and handling no current state information
-deleting review updates review slice correctly, but not session slice (sill in user.reviews and reviews)
-have created/updated/deleted reviews calculate and return numReviews and avgRating as well as spotId
 remove redundant user session settings (just depend on
 user object setting: reviews, spots, bookings)
 test and check all interdependency reducers are correct
 
+check every App start page for doing browser refresh and handling no current state information
 
 
 create review causes error for empty list

--- a/lastBranchNotes.txt
+++ b/lastBranchNotes.txt
@@ -1,39 +1,16 @@
 
 Last branch notes
 
-MONDAY/TUESDAY
-converting to flattened normalized store
-Noted all the places for interdependency and ensure
-  reducers are all modified
-Changed return status code for create review
-changed all things that return Spot info to include previewUrl
-spot seeders add a previewUrl
-spot creation to insists on preview url set
-migration and model to set allowNull false for previewUrl
-changed Review table column/model instvar poorly name "review" to "commentary"
-Ensured all db errors for Auth Me are returned in response
-migrated ti change Spot to have nullish previewUrl
-ran Spot seeders that set previewUrl
-changed SpotImages seeders that no longer create previews
-migration that changed SpotImages to not have preview
-changed all backend code that touches preview or previewImage
-changed all frontend code that depends on preview or previewImage
-changed all frontend interfaces that create a preview image
-changed utils that pass a preview image along with support images
-changed migrations and models to not allow previewUrl null
-changed Review columns/model instVar from "review" to "commentary"
-changed seeders to support commentary
-changed backend validation to support commentary
-changed frontend to handle commentary
-added spot numReviews=0/avgRating=null to frontend    creation store values, and to edit if avgRating undefined
-Fixed landing page "loses" previewUrl display; but refresh brings it back
-Adding new review does for existing spots correctly update review count and average
-Updating Spot works correctly for existing Spot
+SATURDAY/SUNDAY
+Manage spots doesn't load
+can update freshly created spot
+delete spot changes no longer impact userId info
+Added Callout with price night, small review avg, Reserve button
+StarRatings added to SpotDetails' callout box
+Ensured spot delete updates landing pages/manage spot pages
+
+create review causes error for empty list
+Login modal doesn't autoclose after successful login
 
 
-NOt displaying additional images on spot details
-Post your review button incorrectly stays up after posting
-
-
-
-Extra reading of DB
+Check out create and edit spots; after getting Manage Spots

--- a/storeLayout.js
+++ b/storeLayout.js
@@ -5,7 +5,7 @@ new STORE layout (except since users cannot be deleted, and all
     with session currently, they are never listed or ordered)
 
    {
-     session:
+     session: CD Spot user.spot, CD Review,
      users: // session signup creates
      spots:  // landing, details, CUD Spot
      reviews: // from all reviews for spot/user; CUD Review
@@ -15,28 +15,19 @@ new STORE layout (except since users cannot be deleted, and all
    },
    */
    /* session */ /*
-   {
+  {
     user: user || null
-    spots: {[spotId]: spot,},
-    reviews: {[reviewId}: review,},
-    bookings: {[bookingId]: booking,},
-    id: (really all the user stuff below goes here)
-   }
-   */
-
-   /* users */ /* interested in spot/booking/review delete */ /*
-   {
+    id: // normalized users
+    {
      [userId]:
-       {
+       { // partial from review reads
          id,
          firstName,
          lastName,
 
-         // additional detail on login
+         // additional detail on login (passwords only in db)
          email,
          username,
-         createdAt,  /// TODO?
-         updatedAt   /// TODO?
 
          // additional detail w/ current spots/review/bookings
          spots: [spotIds,],
@@ -45,7 +36,8 @@ new STORE layout (except since users cannot be deleted, and all
          // spotQuery: [landingPageQueryParamString], // TODO
          // currentPage: 3 // last displayed page of info // TODO
        }
-   }
+    }
+  }
    */
    /* spots */ /*
    {
@@ -72,7 +64,7 @@ new STORE layout (except since users cannot be deleted, and all
 
              // additional info; Details page gets images & reviews
              // reserve button gets bookings
-             images: [spotImageIds,], // spotDetails(singleSpot)
+             images: [spotImageIds,], // spotDetails
              reviews: [reviewIds,], // allSpotReviews
              // bookings: [bookingIds,], // perhaps only ids with future endDates
            },
@@ -83,7 +75,7 @@ new STORE layout (except since users cannot be deleted, and all
 
    /* reviews */ /* interested in spot delete */ /*
    {
-     id: // from all reviews for spot/user; CUD
+     id: // from all reviews for spot/user; CUD Review; D Spot
        {
          [reviewId]:
            {


### PR DESCRIPTION
Manage spots now loads
can update freshly created spot
delete spot changes no longer impact userId info
Added Callout with price night, small review avg, Reserve button
StarRatings added to SpotDetails' callout box
Ensured spot delete updates landing pages/manage spot pages
Create and then edit/update new spot works
deleting review updates reviews/session/spots slices correctly
created/updated/deleted reviews calculate and return numReviews and avgRating as well as spotId