### PR TITLE
login closes; placeholders used in details; spot create may skip images

### DIFF
--- a/frontend/src/components/LoginFormModal/index.js
+++ b/frontend/src/components/LoginFormModal/index.js
@@ -18,7 +18,7 @@ function LoginFormModal() {
     setCredential("demo@user.io");
     setPassword("password");
     dispatch(thunkLogin({ "credential": "demo@user.io", "password": "password" }));
-    setTimeout(closeModal,500)
+    setTimeout(closeModal, 300)
   }
 
   const handleSubmit = (e) => {
@@ -33,7 +33,10 @@ function LoginFormModal() {
         // const data = await res.json();
         if (data && data.errors) {
           setErrors(data.errors);
-        } else history.push("/")
+        } else {
+          closeModal();
+          history.push("/")
+        }
       });
   };
 

--- a/frontend/src/components/SpotDetails/index.js
+++ b/frontend/src/components/SpotDetails/index.js
@@ -18,6 +18,7 @@ function SpotDetails() {
     let otherImages = []
     console.log("🚀 ~ file: index.js:15 ~ SpotDetails ~ id, spotImages, imageIds, spot:", id, spotImages, imageIds, spot);
     // const [rerender, setRerender] = useState({})
+    const placeholderSrc = "https://placehold.co/200?text=Photo+needed&font=montserrat"
 
 
   if (!imageIds) {
@@ -30,9 +31,11 @@ function SpotDetails() {
   } else if (ref.current[id]) delete ref.current[id]
 
   for (const imageId of imageIds)
-  otherImages.push(spotImages[imageId])
+    otherImages.push(spotImages[imageId])
   if (otherImages.length > 4)
     otherImages = otherImages.slice(0,4)
+  while (otherImages.length < 4)
+    otherImages.push({id: placeholderSrc, url:placeholderSrc})
 
   const owner = spot.Owner;
   function handleReserveClick(){
@@ -49,9 +52,8 @@ function SpotDetails() {
             <div className="spotDetailsPreviewDiv"><img className="spotDetailsPreviewImg" alt='preview' src={spot.previewUrl}></img></div>
             <div className="spotDetailsImagesDiv">
                 {otherImages && otherImages.length && otherImages.map(si => (
-                    <img key={si.id} className="spotDetailsSmallImg" alt='' src={si.url}></img>
-                ))
-                }
+                    <img key={si.id} className="spotDetailsSmallImg" alt='' src={si.url}></img>))}
+                {}
             </div>
         </div>
         <section className="spotDetailsSection">

--- a/frontend/src/components/SpotForm/index.js
+++ b/frontend/src/components/SpotForm/index.js
@@ -58,9 +58,9 @@ function SpotForm ({spot, formType}) {
       else if (!validImageUrl(previewUrl)) validations.previewUrl = extensionError
       if (!isEdit) { /* TODO For now; skip support images on Update */
       if (supportUrl1 && !validImageUrl(supportUrl1)) validations.supportUrl1 = extensionError
-      if (supportUrl1 && !validImageUrl(supportUrl2)) validations.supportUrl2 = extensionError
-      if (supportUrl1 && !validImageUrl(supportUrl3)) validations.supportUrl3 = extensionError
-      if (supportUrl1 && !validImageUrl(supportUrl4)) validations.supportUrl4 = extensionError
+      if (supportUrl2 && !validImageUrl(supportUrl2)) validations.supportUrl2 = extensionError
+      if (supportUrl3 && !validImageUrl(supportUrl3)) validations.supportUrl3 = extensionError
+      if (supportUrl4 && !validImageUrl(supportUrl4)) validations.supportUrl4 = extensionError
       }
       setErrors(validations);
       if (Object.keys(validations).length === 0) {

--- a/frontend/src/components/SpotTile/index.js
+++ b/frontend/src/components/SpotTile/index.js
@@ -8,7 +8,7 @@ import OpenModalButton from '../OpenModalButton';
 import SpotDeleteFormModal from '../SpotDeleteFormModal';
 import { thunkReadSpot } from '../../store/spots';
 
-const placeholderSrc = "https://placehold.co/100?text=Photo+needed&font=montserrat"
+const placeholderSrc = "https://placehold.co/200?text=Photo+needed&font=montserrat"
 
 function SpotTile ({spotId, spot, isManaged}) {
   console.log("🚀 rendering SpotTile ~ spotId, spot:", spotId, spot)

--- a/lastBranchNotes.txt
+++ b/lastBranchNotes.txt
@@ -1,16 +1,10 @@
 
 Last branch notes
 
-SATURDAY/SUNDAY
-Manage spots now loads
-can update freshly created spot
-delete spot changes no longer impact userId info
-Added Callout with price night, small review avg, Reserve button
-StarRatings added to SpotDetails' callout box
-Ensured spot delete updates landing pages/manage spot pages
-Create and then edit/update new spot works
-deleting review updates reviews/session/spots slices correctly
-created/updated/deleted reviews calculate and return numReviews and avgRating as well as spotId
+MONDAY
+Login modal again autocloses after successful login
+Spot create form no longer insists on extra images
+Placeholders used in spotdetails if not enough images
 
 remove redundant user session settings (just depend on
 user object setting: reviews, spots, bookings)
@@ -18,9 +12,6 @@ test and check all interdependency reducers are correct
 
 check every App start page for doing browser refresh and handling no current state information
 
-
-create review causes error for empty list
-Login modal doesn't autoclose after successful login
 
 review slice correctly updated with delete/create; however:
 spot not updated with create (but was with delete)


### PR DESCRIPTION

Login modal again autocloses after successful login
Spot create form no longer insists on extra images
Placeholders used in spotdetails if not enough images