### PR TITLE
render failure on copy of date util file

### DIFF
--- a/backend/utils/normalizeDate.js
+++ b/backend/utils/normalizeDate.js
@@ -8,7 +8,7 @@
 // can turn into such a millisecond value. That
 // function will return NaN if unable to parse argument.
 
-export function findAvailableRange(dateTuples, stayLength, searchDelay, lastDate) {
+function findAvailableRange(dateTuples, stayLength, searchDelay, lastDate) {
     /*
      * dateTuples is a sorted array of 2-element subarrays of
      * ascending start/end dates for already booked stays. stayLength
@@ -67,12 +67,12 @@ function typeCheck(date) {
     return (typeof date === 'string' || typeof date === 'number')
         ? new Date(date) : date
 }
-export function dayDate(date) { // return Date instance with local time 0
+function dayDate(date) { // return Date instance with local time 0
     date = typeCheck(date);
     return new Date(date.toDateString())
 }
 
-export function ymd(date) { // return a string of YYYY-MM-DD of the date
+function ymd(date) { // return a string of YYYY-MM-DD of the date
     date = typeCheck(date);
     return date.toISOString().split('T')[0]
 }
@@ -152,3 +152,6 @@ because if a new range entirely OVERLAPS
 some existing range, then you need the original
 query as well.
 */
+
+
+module.exports = { addDays, dayDate, dayGTE, dayLTE, findAvailableRange, ymd, ymdt }

--- a/frontend/src/components/BookingCalendar/index.js
+++ b/frontend/src/components/BookingCalendar/index.js
@@ -34,6 +34,8 @@ function BookingCalendar() {
     const tomorrow = addDays(today, 1)
     const yearOut = addDays(today, 365)
     const [value, setValue] = useState([today, tomorrow]);
+    const [activeStartDate, setActiveStartDate] = useState(today); // work around bug
+
 
     function handleChange(nextValue) {
       setValue(nextValue);
@@ -47,6 +49,13 @@ function BookingCalendar() {
            return disabledDates.find(dDate => isSameDay(dDate, date));
     }
 
+
+    const onActiveStartDateChange = data => {
+        if (data.action !== "onChange") {
+            setActiveStartDate(data.activeStartDate);
+        }
+    }
+
     /*
      * activeStartDate the day to begin showing calendar
      * allowPartialRange whether a range can only be partly filled in on return
@@ -57,7 +66,7 @@ function BookingCalendar() {
      * formatDay (if needed to override default formatting)
      * formatMonth (if needed to override default formatting)
      * formatMonthYear (if needed to override default formatting)
-     * goToRangeStartOnSelect
+     * goToRangeStartOnSelect (needed for bug control)
      * inputRef
      * locale
      * maxDate set for a year out; evetually Host sets per location
@@ -78,7 +87,7 @@ function BookingCalendar() {
    return (
        <div className="bookingCalendarDiv">
     <Calendar
-        activeStartDate={today}
+        activeStartDate={activeStartDate}
         allowPartialRange={true}
         defaultValue={value}
         calendarType="gregory"

--- a/lastBranchNotes.txt
+++ b/lastBranchNotes.txt
@@ -1,27 +1,6 @@
 
 Last branch notes
 
-
-TUESDAY
-Redid Spot/Review deleteFormModal for reuse, so all 3 resources (adding booking) use same component with different props
-Retest all 3 resource deletions
-Improved error-handling and display on modal
-Delete Booking functionality in place
-DRYed readOfMultiple/Delete/Create of spots/reviews/bookings in session reducer
-Connected Delete for Bookings and tested
-
-TUESDAY AFTERNOON
-Initial default CreateBookingsPage
-Added route in App
-Connected Reserve button
-Added findAvailableRange to date utilities
-REVIEW NPM Calendar frameworks; picked React-Calendar
-https://www.npmjs.com/package/react-calendar
-Initial App route /calendar for testing calendar; will
-  change to modal after getting basic functionality
-  correct
-added react-calendar to npm packages used after getting Dan's permission
-
 WEDNESDAY
 Continue work on react-calendar
 


### PR DESCRIPTION
Render deployment failed, apparently complaining about export function findAvailableRange(), which worked fine in development. I had changed the date utilties file (copied from the backend) to ES6 imports; but to attempt to work around Render's failure I have put the backend version back to a ES5 import approach; we'll see.